### PR TITLE
Fix error for running d1-and-sveltekit example

### DIFF
--- a/content/d1/examples/d1-and-sveltekit.md
+++ b/content/d1/examples/d1-and-sveltekit.md
@@ -39,7 +39,7 @@ import type { RequestHandler } from "@sveltejs/kit";
 export async function GET({ request, platform }) {
   let result = await platform.env.DB.prepare(
     "SELECT * FROM users LIMIT 5"
-  ).run();
+  ).all();
   return new Response(JSON.stringify(result));
 }
 ```


### PR DESCRIPTION
When using `run()` for the SELECT query, will get the following error:

```
Error: D1_ERROR: Error: SQL execute error: Execute returned results - did you mean to call query?
```

From the [doc](https://developers.cloudflare.com/d1/platform/client-api/#await-stmtrun), `run()` should return no results.
